### PR TITLE
add authContext and authProvider

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,21 +1,12 @@
 import AppRoutes from './components/appRoutes';
 import Footer from './components/footer';
 import Header from './components/header';
+import { AuthProvider } from './components/auth/authProvider';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 const root = document.getElementById('root');
-
-// TODO: implement authentication
-interface AuthContextType {
-  children: React.ReactNode;
-}
-
-const AuthProvider: React.FC<AuthContextType> = ({ children }) => {
-  // TODO: implement authentication
-  return <>{children}</>;
-}
 
 const App: React.FC = () => {
   return (

--- a/src/components/appRoutes.tsx
+++ b/src/components/appRoutes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
+import Admin from '../pages/admin';
 import Board from '../pages/board';
 import BoardDetail from '../components/board/boardDetail';
 import Home from '../pages/home';
@@ -15,6 +16,7 @@ const AppRoutes: React.FC = () => {
       <Route path="/board/:id" element={<BoardDetail />} />
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
+      <Route path="/admin" element={<Admin />} />
       <Route path="*" element={<NotFound />} /> {/* 404 Not Found */}
     </Routes>
   );

--- a/src/components/auth/authProvider.tsx
+++ b/src/components/auth/authProvider.tsx
@@ -1,0 +1,70 @@
+// src/components/authProvider.tsx
+import React, { createContext, useState, useEffect } from 'react';
+import { AuthContextProps } from '../../types';
+
+export const AuthContext = createContext<AuthContextProps>({
+  token: null,
+  isAuthenticated: false,
+  login: async () => { },
+  logout: () => { },
+});
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(null);
+
+
+  // Restore JWT token when the app is loaded
+  useEffect(() => {
+    const token = localStorage.getItem('jwtToken');
+    if (token) {
+      setToken(token);
+    }
+  }, []);
+
+  // Login function
+  const login = async (username: string, password: string) => {
+    try {
+      // Call the login API
+      const response = await fetch('/api/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username, password }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Login failed');
+      }
+
+      const data = await response.json();
+      setToken(data.token);
+      localStorage.setItem('jwtToken', data.token);
+    } catch (error) {
+      console.error('Login Failed: ', error);
+    }
+  };
+
+  const logout = () => {
+    setToken(null);
+    localStorage.removeItem('jwtToken');
+  };
+
+  const contextValue: AuthContextProps = {
+    token,
+    isAuthenticated: !!token,
+    login,
+    logout,
+  };
+
+  return (
+    <AuthContext.Provider value={contextValue}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,32 +1,38 @@
 // src/components/header.tsx
 import '../global.css';
 import './header.css';
-import React from 'react';
+import React, { useContext } from 'react';
 import { AppBar, Toolbar, Typography, Button, Box } from '@mui/material';
 import { Link } from 'react-router-dom';
+import { AuthContext } from '../components/auth/authProvider';
 
-/* Deprecated
-const Header: React.FC = () => {
+const RightButtonLogin: React.ReactNode = (
+  <>
+    <Button color="inherit" component={Link} to="/register">
+      회원가입
+    </Button>
+    <Button color="inherit" component={Link} to="/login">
+      로그인
+    </Button>
+  </>
+);
+
+const RightButtonLogout = (logout: () => void): React.ReactNode => {
   return (
-    <header className="header">
-      <nav className="header-container">
-        <ul>
-          <li>
-            <Link to="/">Home</Link>
-          </li>
-          <li>
-            <Link to="/about">About</Link>
-          </li>
-          <li>
-            <Link to="/board">Board</Link>
-          </li>
-        </ul>
-      </nav>
-    </header>
-  );
-}
-*/
+    <>
+      <Button color="inherit" component={Link} to="/profile">
+        회원정보
+      </Button>
+      <Button color="inherit" onClick={logout}>
+        로그아웃
+      </Button>
+    </>
+  )
+};
+
 const Header: React.FC = () => {
+  const { isAuthenticated, logout } = useContext(AuthContext);
+
   return (
     <AppBar position="static" sx={{ marginBottom: '1rem', backgroundColor: '#555' }}>
       <Toolbar sx={{ display: 'flex' }}>
@@ -49,12 +55,7 @@ const Header: React.FC = () => {
 
         {/* 오른쪽 영역: Register, Login 버튼 */}
         <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
-          <Button color="inherit" component={Link} to="/register">
-            Register
-          </Button>
-          <Button color="inherit" component={Link} to="/login">
-            Login
-          </Button>
+          {!isAuthenticated ? RightButtonLogin : RightButtonLogout(logout)}
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,15 @@
+// src/pages/admin/index.tsx
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import NotFound from '../notFound';
+
+const Admin: React.FC = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<div>Admin</div>} />
+      <Route path="*" element={<NotFound />} /> {/* 404 Not Found */}
+    </Routes>
+  );
+}
+
+export default Admin;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,11 +1,20 @@
 // src/pages/login.tsx
-import React from 'react';
+import React, { useState, useContext } from 'react';
 import { Container, Box, Paper, Typography, TextField, Button } from '@mui/material';
+import { AuthContext } from '../components/auth/authProvider';
 
 const Login: React.FC = () => {
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const { login } = useContext(AuthContext);
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // Add your login logic here, e.g., authentication calls.
+    try {
+      await login(id, password);
+    } catch (error) {
+      console.error("Login Failed", error);
+    }
   };
 
   return (
@@ -22,12 +31,14 @@ const Login: React.FC = () => {
           </Typography>
           <form onSubmit={handleSubmit}>
             <TextField
-              label="Email Address"
+              label="ID"
               variant="outlined"
               margin="normal"
               fullWidth
               required
-              type="email"
+              type="id"
+              value={id}
+              onChange={(e) => setId(e.target.value)}
             />
             <TextField
               label="Password"
@@ -36,6 +47,8 @@ const Login: React.FC = () => {
               fullWidth
               required
               type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
             <Button
               type="submit"

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -20,3 +20,10 @@ export interface BoardProps {
 export interface BoardListProps {
   boards: BoardProps[];
 }
+
+export interface AuthContextProps {
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void;
+};

--- a/vi
+++ b/vi
@@ -1,0 +1,194 @@
+diff --git a/src/app.tsx b/src/app.tsx
+index 34be236..d72af59 100644
+--- a/src/app.tsx
++++ b/src/app.tsx
+@@ -1,22 +1,13 @@
+ import AppRoutes from './components/appRoutes';
+ import Footer from './components/footer';
+ import Header from './components/header';
++import { AuthProvider } from './components/auth/authProvider';
+ import React from 'react';
+ import ReactDOM from 'react-dom/client';
+ import { BrowserRouter as Router } from 'react-router-dom';
+ 
+ const root = document.getElementById('root');
+ 
+-// TODO: implement authentication
+-interface AuthContextType {
+-  children: React.ReactNode;
+-}
+-
+-const AuthProvider: React.FC<AuthContextType> = ({ children }) => {
+-  // TODO: implement authentication
+-  return <>{children}</>;
+-}
+-
+ const App: React.FC = () => {
+   return (
+     <Router basename='/'>
+diff --git a/src/components/appRoutes.tsx b/src/components/appRoutes.tsx
+index 6823cb0..71b3307 100644
+--- a/src/components/appRoutes.tsx
++++ b/src/components/appRoutes.tsx
+@@ -1,5 +1,6 @@
+ import React from 'react';
+ import { Routes, Route } from 'react-router-dom';
++import Admin from '../pages/admin';
+ import Board from '../pages/board';
+ import BoardDetail from '../components/board/boardDetail';
+ import Home from '../pages/home';
+@@ -15,6 +16,7 @@ const AppRoutes: React.FC = () => {
+       <Route path="/board/:id" element={<BoardDetail />} />
+       <Route path="/login" element={<Login />} />
+       <Route path="/register" element={<Register />} />
++      <Route path="/admin" element={<Admin />} />
+       <Route path="*" element={<NotFound />} /> {/* 404 Not Found */}
+     </Routes>
+   );
+diff --git a/src/components/header.tsx b/src/components/header.tsx
+index 2638d6d..5d681bb 100644
+--- a/src/components/header.tsx
++++ b/src/components/header.tsx
+@@ -1,32 +1,38 @@
+ // src/components/header.tsx
+ import '../global.css';
+ import './header.css';
+-import React from 'react';
++import React, { useContext } from 'react';
+ import { AppBar, Toolbar, Typography, Button, Box } from '@mui/material';
+ import { Link } from 'react-router-dom';
++import { AuthContext } from '../components/auth/authProvider';
+ 
+-/* Deprecated
+-const Header: React.FC = () => {
++const RightButtonLogin: React.ReactNode = (
++  <>
++    <Button color="inherit" component={Link} to="/register">
++      회원가입
++    </Button>
++    <Button color="inherit" component={Link} to="/login">
++      로그인
++    </Button>
++  </>
++);
++
++const RightButtonLogout = (logout: () => void): React.ReactNode => {
+   return (
+-    <header className="header">
+-      <nav className="header-container">
+-        <ul>
+-          <li>
+-            <Link to="/">Home</Link>
+-          </li>
+-          <li>
+-            <Link to="/about">About</Link>
+-          </li>
+-          <li>
+-            <Link to="/board">Board</Link>
+-          </li>
+-        </ul>
+-      </nav>
+-    </header>
+-  );
+-}
+-*/
++    <>
++      <Button color="inherit" component={Link} to="/profile">
++        회원정보
++      </Button>
++      <Button color="inherit" onClick={logout}>
++        로그아웃
++      </Button>
++    </>
++  )
++};
++
+ const Header: React.FC = () => {
++  const { isAuthenticated, logout } = useContext(AuthContext);
++
+   return (
+     <AppBar position="static" sx={{ marginBottom: '1rem', backgroundColor: '#555' }}>
+       <Toolbar sx={{ display: 'flex' }}>
+@@ -49,12 +55,7 @@ const Header: React.FC = () => {
+ 
+         {/* 오른쪽 영역: Register, Login 버튼 */}
+         <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
+-          <Button color="inherit" component={Link} to="/register">
+-            Register
+-          </Button>
+-          <Button color="inherit" component={Link} to="/login">
+-            Login
+-          </Button>
++          {!isAuthenticated ? RightButtonLogin : RightButtonLogout(logout)}
+         </Box>
+       </Toolbar>
+     </AppBar>
+diff --git a/src/pages/login.tsx b/src/pages/login.tsx
+index fde6b6b..2c4d4b7 100644
+--- a/src/pages/login.tsx
++++ b/src/pages/login.tsx
+@@ -1,11 +1,20 @@
+ // src/pages/login.tsx
+-import React from 'react';
++import React, { useState, useContext } from 'react';
+ import { Container, Box, Paper, Typography, TextField, Button } from '@mui/material';
++import { AuthContext } from '../components/auth/authProvider';
+ 
+ const Login: React.FC = () => {
+-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
++  const { login } = useContext(AuthContext);
++  const [id, setId] = useState('');
++  const [password, setPassword] = useState('');
++
++  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+     event.preventDefault();
+-    // Add your login logic here, e.g., authentication calls.
++    try {
++      await login(id, password);
++    } catch (error) {
++      console.error("Login Failed", error);
++    }
+   };
+ 
+   return (
+@@ -22,12 +31,14 @@ const Login: React.FC = () => {
+           </Typography>
+           <form onSubmit={handleSubmit}>
+             <TextField
+-              label="Email Address"
++              label="ID"
+               variant="outlined"
+               margin="normal"
+               fullWidth
+               required
+-              type="email"
++              type="id"
++              value={id}
++              onChange={(e) => setId(e.target.value)}
+             />
+             <TextField
+               label="Password"
+@@ -36,6 +47,8 @@ const Login: React.FC = () => {
+               fullWidth
+               required
+               type="password"
++              value={password}
++              onChange={(e) => setPassword(e.target.value)}
+             />
+             <Button
+               type="submit"
+diff --git a/src/types.tsx b/src/types.tsx
+index aab5655..95b630c 100644
+--- a/src/types.tsx
++++ b/src/types.tsx
+@@ -20,3 +20,10 @@ export interface BoardProps {
+ export interface BoardListProps {
+   boards: BoardProps[];
+ }
++
++export interface AuthContextProps {
++  token: string | null;
++  isAuthenticated: boolean;
++  login: (username: string, password: string) => Promise<void>
++  logout: () => void;
++};


### PR DESCRIPTION
# PR 제목:
인증 컨텍스트 및 라우트 업데이트 구현

# PR 설명:
이번 PR에서는 인증 구현을 리팩토링하고 일부 라우트 구성을 업데이트했습니다. 주요 변경 사항은 다음과 같습니다.

- 인증 컨텍스트 업데이트:
    - `app.tsx`에서 임시로 구현했던 `AuthProvider`를 제거하고 `./components/auth/authProvider`에서 가져온 실제 구현으로 대체했습니다.
    - `login.tsx`에서 `useContext(AuthContext)`를 사용하여 `login` 함수를 호출하도록 변경하고, 아이디와 패스워드 입력을 위한 상태 관리를 추가했습니다.
    - jwtToken을 이용한 인증 방식을 사용합니다.

- 헤더 컴포넌트 개선
    - `header.tsx`에서 인증 상태(`AuthContext`)에 따라 로그인/회원가입 버튼과 프로필/로그아웃 버튼을 조건부로 렌더링하도록 수정했습니다.
    
- 라우트 업데이트
    - `appRoutes.tsx`에 `/admin` 경로를 추가하여 Admin 페이지가 렌더링되도록 수정했습니다.
    - 아직 기능 구형은 되어있지 않습니다.
    
# 비고
- 아직 Backend 개발이 되지 않았기 때문에 백엔드가 만들어진 뒤 테스트가 필요합니다.
