### PR TITLE
chore: set proxy for FE, BE connection

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,10 @@ module.exports = {
       directory: path.join(__dirname, 'dist'),
     },
     compress: true,
-    port: 3000,
+    port: 3001,
+    proxy: {
+      '/api': 'http://localhost:3000', // ✅ 프록시 설정
+    },
     hot: true,
     open: true,
     historyApiFallback: true,


### PR DESCRIPTION
# FE 포트 변경 및 API 프록시 설정
1.	프론트엔드(FE)는 이제 3001번 포트에서 동작합니다.
2.	FE에서 /api 경로로 호출할 경우, 자동으로 3000번 포트로 프록시됩니다.